### PR TITLE
Fix an out-of-bounds read on transmitting the encoder ticks

### DIFF
--- a/CRS RC Car uC UFQ 32-pin/Core/Src/main.c
+++ b/CRS RC Car uC UFQ 32-pin/Core/Src/main.c
@@ -23,6 +23,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include "stdbool.h"
+#include <string.h>
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -129,19 +130,15 @@ int main(void)
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
-  int i=0;
+
   while (1)
   {
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
-	  for (i=0;i<=BUFFERSIZE; i++ )
-	  {
-		  send_buffer[i] = TX_Buffer[i];
-	  }
-
-	   HAL_SPI_Transmit_DMA(&hspi1,send_buffer, BUFFERSIZE);
-	   while(HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY);
+	  memcpy(send_buffer, TX_Buffer, BUFFERSIZE);
+	  HAL_SPI_Transmit_DMA(&hspi1,send_buffer, BUFFERSIZE);
+	  while(HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY);
 
   }
   /* USER CODE END 3 */


### PR DESCRIPTION
Instead of manually looping over the length of the buffer, a simpler `memcpy` statement was chosen. The length of the copied bytes now also matches the allocated buffer length.